### PR TITLE
Update integrate.mdx (flutter)

### DIFF
--- a/src/fragments/start/getting-started/flutter/integrate.mdx
+++ b/src/fragments/start/getting-started/flutter/integrate.mdx
@@ -153,7 +153,7 @@ class TodoItem extends StatelessWidget {
               ),
             ),
             Icon(
-                todo.isCompleted
+                todo.isComplete
                     ? Icons.check_box
                     : Icons.check_box_outline_blank,
                 size: iconSize),


### PR DESCRIPTION
Fix "The getter 'isCompleted' isn't defined for the type 'Todo'."

_Issue #, if available:_

_Description of changes:_
I was following the `Getting Started` docs for creating a To-Do app using `amplify-flutter`. On the integration step, I copied the boilerplate UI code from the docs. `todo.isCompleted` was giving a `not-defined` error. Changing that to `complete` resolved the issue and I could run the app.

Error message:
```
The getter 'isCompleted' isn't defined for the type 'Todo'.
Try importing the library that defines 'isCompleted', correcting the name to the name of an existing getter, or defining a getter or field named 'isCompleted'.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
